### PR TITLE
修正自摸莊家台計算並新增簡易規則開關

### DIFF
--- a/mahjong-calculator.html
+++ b/mahjong-calculator.html
@@ -129,12 +129,49 @@
     }
 
     .transaction-list li { margin-bottom: 6px; }
+
+    .rule-toggle-wrap {
+      margin: 8px 0 14px;
+    }
+
+    .btn-small {
+      padding: 4px 10px;
+      font-size: 0.82rem;
+      border-radius: 999px;
+      color: #1d4ed8;
+      border-color: #bfdbfe;
+      background: #eff6ff;
+    }
+
+    .rules-box {
+      display: none;
+      margin-top: 8px;
+      padding: 10px 12px;
+      background: #f8fafc;
+      border: 1px dashed #cbd5e1;
+      border-radius: 10px;
+      font-size: 0.86rem;
+      color: #475569;
+    }
+
+    .rules-box.show {
+      display: block;
+    }
   </style>
 </head>
 <body>
   <div class="container">
     <h1>麻將計算器</h1>
     <p>設定一台金額、底分金額與玩家名稱，快速記錄每一局並自動輪調莊家，最後可一鍵結算誰該給誰多少錢。</p>
+    <div class="rule-toggle-wrap">
+      <button id="toggleRulesBtn" class="btn-small" type="button">顯示簡易規則</button>
+      <div id="rulesBox" class="rules-box">
+        <strong>自摸（依明星三缺一簡化）</strong><br>
+        1. 自摸時，若付款方是莊家，該筆多算 1 台（莊家台）。<br>
+        2. 自摸時，若胡牌者是莊家，三家皆各多算 1 台。<br>
+        3. 每筆金額 = 底分 +（原台數 + 莊家台）× 一台金額。
+      </div>
+    </div>
 
     <div class="grid">
       <section class="card">
@@ -231,7 +268,9 @@
       dealerText: document.getElementById("dealerText"),
       roundsBody: document.getElementById("roundsBody"),
       totalsBody: document.getElementById("totalsBody"),
-      transactions: document.getElementById("transactions")
+      transactions: document.getElementById("transactions"),
+      toggleRulesBtn: document.getElementById("toggleRulesBtn"),
+      rulesBox: document.getElementById("rulesBox")
     };
 
     function loadState() {
@@ -278,6 +317,12 @@
       return state.config.baseAmount + state.config.taiAmount * taiCount;
     }
 
+    function getDealerBonusTai({ winType, winner, payer, dealerIndex }) {
+      if (winType !== "selfDraw") return 0;
+      if (winner === dealerIndex || payer === dealerIndex) return 1;
+      return 0;
+    }
+
     function getPaymentMultiplier(winner, payer, dealerIndex) {
       if (winner === dealerIndex || payer === dealerIndex) {
         return 2;
@@ -292,17 +337,20 @@
           .map((_, playerIndex) => playerIndex)
           .filter((playerIndex) => playerIndex !== winner)
           .map((payer) => {
-            const multiplier = getPaymentMultiplier(winner, payer, dealerIndex);
+            const dealerBonusTai = getDealerBonusTai({ winType, winner, payer, dealerIndex });
+            const amount = calcRoundAmount(taiCount + dealerBonusTai);
             return {
               from: payer,
               to: winner,
-              amount: baseRoundAmount * multiplier
+              amount,
+              taiCount,
+              dealerBonusTai
             };
           });
       }
 
       const multiplier = getPaymentMultiplier(winner, loser, dealerIndex);
-      return [{ from: loser, to: winner, amount: baseRoundAmount * multiplier }];
+      return [{ from: loser, to: winner, amount: baseRoundAmount * multiplier, taiCount, dealerBonusTai: 0, multiplier }];
     }
 
     function getTotals() {
@@ -367,7 +415,10 @@
             ? round.transfers
             : [{ from: round.loser, to: round.winner, amount: round.amount || 0 }];
           const amountText = transfers
-            .map((tx) => `${state.config.players[tx.from]}→${state.config.players[tx.to]}：${tx.amount}`)
+            .map((tx) => {
+              const taiInfo = Number(tx.dealerBonusTai) > 0 ? `（${round.taiCount}+莊家${tx.dealerBonusTai}台）` : "";
+              return `${state.config.players[tx.from]}→${state.config.players[tx.to]}：${tx.amount}${taiInfo}`;
+            })
             .join("<br>");
           const noteText = [isSelfDraw ? "自摸" : "放槍", round.note]
             .filter(Boolean)
@@ -493,11 +544,18 @@
       el.statusText.textContent = "已清空所有資料。";
     }
 
+    function toggleRules() {
+      const shouldShow = !el.rulesBox.classList.contains("show");
+      el.rulesBox.classList.toggle("show", shouldShow);
+      el.toggleRulesBtn.textContent = shouldShow ? "隱藏簡易規則" : "顯示簡易規則";
+    }
+
     el.saveConfigBtn.addEventListener("click", saveConfig);
     el.addRoundBtn.addEventListener("click", addRound);
     el.winTypeSelect.addEventListener("change", toggleLoserInput);
     el.resetRoundBtn.addEventListener("click", resetRounds);
     el.clearAllBtn.addEventListener("click", clearAll);
+    el.toggleRulesBtn.addEventListener("click", toggleRules);
 
     loadState();
     renderAll();


### PR DESCRIPTION
### Motivation
- 修正自摸時計算莊家台的行為以符合明星三缺一的計算邏輯，避免自摸金額計算錯誤。 
- 讓使用者可以在介面上快速查看簡化規則以便確認計算方式。 

### Description
- 在 `mahjong-calculator.html` 中新增 `getDealerBonusTai`，用於判斷自摸時是否應加 1 台（當胡牌者或付款方為莊家時）。
- 調整 `buildTransfers`，自摸時計算金額改為使用 `calcRoundAmount(taiCount + dealerBonusTai)` 並在 transfer 物件中保存 `taiCount` 與 `dealerBonusTai` 資訊以便顯示明細。 
- 保留放槍（discard）既有的莊家倍數邏輯 (`getPaymentMultiplier`) 並維持放槍金額乘上該倍數的行為。 
- 新增 UI 元素與樣式：`#toggleRulesBtn` 與 `#rulesBox`，提供「顯示/隱藏簡易規則」的按鈕與可切換的規則區塊，並在紀錄列中顯示包含莊家台的說明文字。 

### Testing
- 執行 `git diff --check`，檢查結果沒有報錯（通過）。
- 提交變更成功（已執行 `git commit` 並產生變更）。
- 嘗試使用瀏覽器自動化腳本截圖以驗證 UI，但在執行環境中無法載入本機檔案/本地 HTTP 服務（出現 `ERR_EMPTY_RESPONSE` / `ERR_FILE_NOT_FOUND`），因此截圖驗證未完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996b65f1608832691c12f3f6c6194fb)